### PR TITLE
Add GDB support and use merged binary

### DIFF
--- a/gdbserver.py
+++ b/gdbserver.py
@@ -1,0 +1,76 @@
+import asyncio
+import socket
+from typing import Awaitable, Callable, Optional
+
+
+def gdbChecksum(text: str):
+    return format(sum(map(ord, text)) & 0xff, '02x')
+
+
+class GDBServer:
+    on_gdb_break: Optional[Callable[[], Awaitable[None]]]
+    on_gdb_message: Optional[Callable[[str], Awaitable[None]]]
+
+    def __init__(self):
+        self._client = None
+        self.on_gdb_break = None
+        self.on_gdb_message = None
+
+    def log(self, message: str):
+        print("[GDB] " + message)
+
+    async def start(self, port: int, host='localhost'):
+        self.server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server.bind((host, port))
+        self.server.listen(1)
+        self.server.setblocking(False)
+
+        loop = asyncio.get_event_loop()
+
+        while True:
+            client, addr = await loop.sock_accept(self.server)
+            self.log('Connected ({}:{})'.format(*addr))
+            loop.create_task(self.handle_client(client))
+
+    async def handle_client(self, client: socket):
+        self._client = client
+        loop = asyncio.get_event_loop()
+        await loop.sock_sendall(client, '+'.encode('utf-8'))
+
+        buf = ''
+        while True:
+            chunk = (await loop.sock_recv(client, 1024))
+            if len(chunk) == 0:
+                break  # Disconnected
+            if (chunk[0] == 3):
+                print("[GDB] BREAK")
+                if self.on_gdb_break:
+                    await self.on_gdb_break()
+                chunk = chunk[1:]
+            buf += chunk.decode('utf-8')
+            dolla = buf.find('$')
+            hash = buf.find('#', dolla)
+            if (dolla < 0 or hash < 0 or hash + 2 > len(buf)):
+                continue
+            cmd = buf[dolla + 1: hash]
+            cksum = buf[hash + 1: hash + 3]
+            buf = buf[hash + 3:]
+            if (gdbChecksum(cmd) != cksum):
+                self.log('Warning: Checksum error in message: {}'.format(cmd))
+                await loop.sock_sendall(client, '-'.encode('utf-8'))
+            elif self.on_gdb_message:
+                await loop.sock_sendall(client, '+'.encode('utf-8'))
+                await self.on_gdb_message(cmd)
+            else:
+                self.log(
+                    'Error: Wokwi Simulator is not connected; ignoring GDB message')
+        self.log("Disconnected")
+        if self._client == client:
+            self.client = None
+
+    async def send_response(self, msg: str):
+        if self._client:
+            await asyncio.get_event_loop().sock_sendall(self._client, msg.encode('utf-8'))
+        else:
+            self.log(
+                'Error: Wokwi sent a GDB response, but GDB is disconnected')

--- a/server.py
+++ b/server.py
@@ -24,17 +24,13 @@ gdb_server = GDBServer()
 async def handle_client(websocket, path):
     msg = await websocket.recv()
     print("Client connected! {}".format(msg))
-    arch="xtensa-esp32-espidf"
-    if (os.getenv('ESP_BOARD') == "esp32c3"):
-        arch="riscv32imc-esp-espidf"
+
     # Send the simulation payload
     await websocket.send(json.dumps({
         "type": "start",
-        "elf": base64_file('target/{}/debug/{}'.format(arch, os.getenv('CURRENT_PROJECT'))),
+        "elf": base64_file('target/{}/debug/{}'.format(os.getenv('ESP_ARCH'), os.getenv('CURRENT_PROJECT'))),
         "espBin": [
-            [os.getenv('ESP_BOOTLOADER_OFFSET', 0x0000), base64_file('bootloader.bin')],
-            [os.getenv('ESP_PARTITION_TABLE_OFFSET', 0x8000), base64_file('partition-table.bin')],
-            [os.getenv('ESP_APP_OFFSET', 0x10000), base64_file('app.bin')],
+            [0x0000, base64_file('app.bin')],
         ]
     }))
 

--- a/server.py
+++ b/server.py
@@ -9,29 +9,39 @@ import subprocess
 import websockets
 import webbrowser
 import time
+from gdbserver import GDBServer
+
 
 PORT = 9012
-
+GDB_PORT = 9333
 
 def base64_file(path: str):
     with open(path, 'rb') as file:
         return base64.b64encode(file.read()).decode('ascii')
 
+gdb_server = GDBServer()
 
-async def hello(websocket, path):
+async def handle_client(websocket, path):
     msg = await websocket.recv()
     print("Client connected! {}".format(msg))
-
+    arch="xtensa-esp32-espidf"
+    if (os.getenv('ESP_BOARD') == "esp32c3"):
+        arch="riscv32imc-esp-espidf"
     # Send the simulation payload
     await websocket.send(json.dumps({
         "type": "start",
-        "elf": base64_file('{}/blink.elf'.format(os.getcwd())),
+        "elf": base64_file('target/{}/debug/{}'.format(arch, os.getenv('CURRENT_PROJECT'))),
         "espBin": [
-            [os.getenv('ESP_BOOTLOADER_OFFSET', 0x0000), base64_file('{}/bootloader.bin'.format(os.getenv('CURRENT_PROJECT')))],
-            [os.getenv('ESP_PARTITION_TABLE_OFFSET', 0x8000), base64_file('{}/partition-table.bin'.format(os.getenv('CURRENT_PROJECT')))],
-            [os.getenv('ESP_APP_OFFSET', 0x10000), base64_file('{}/app.bin'.format(os.getenv('CURRENT_PROJECT')))],
+            [os.getenv('ESP_BOOTLOADER_OFFSET', 0x0000), base64_file('bootloader.bin')],
+            [os.getenv('ESP_PARTITION_TABLE_OFFSET', 0x8000), base64_file('partition-table.bin')],
+            [os.getenv('ESP_APP_OFFSET', 0x10000), base64_file('app.bin')],
         ]
     }))
+
+    gdb_server.on_gdb_message = lambda msg: websocket.send(
+        json.dumps({"type": "gdb", "message": msg}))
+    gdb_server.on_gdb_break = lambda: websocket.send(
+        json.dumps({"type": "gdbBreak"}))
 
     while True:
         msg = await websocket.recv()
@@ -39,21 +49,15 @@ async def hello(websocket, path):
         if msgjson["type"] == "uartData":
             sys.stdout.buffer.write(bytearray(msgjson["bytes"]))
             sys.stdout.flush()
+        elif msgjson["type"] == "gdbResponse":
+            await gdb_server.send_response(msgjson["response"])
         else:
             print("> {}".format(msg))
 
-start_server = websockets.serve(hello, "127.0.0.1", PORT)
+start_server = websockets.serve(handle_client, "127.0.0.1", PORT)
 asyncio.get_event_loop().run_until_complete(start_server)
 
-# ESP32-C3-DevKitC-02
-# board = 325149339656651346
-# ESP32C3 Rust Board
 board = os.getenv('WOKWI_PROJECT_ID')
-if "intro/hardware-check" in os.getenv('CURRENT_PROJECT') or "intro/mqtt" in os.getenv('CURRENT_PROJECT') or "advanced/button-interrupt" in os.getenv('CURRENT_PROJECT'):
-    # ESP32C3 Rust Board with Neopixel
-    board = 328904135759888980
-elif "advanced/i2c-driver" in os.getenv('CURRENT_PROJECT'):
-    board = 329811477748777556
 
 if(os.getenv('USER') == "gitpod"):
     gp_url = subprocess.getoutput("gp url {}".format(PORT))
@@ -67,4 +71,6 @@ if(os.getenv('USER') == "gitpod"):
     open_preview = subprocess.getoutput("gp preview \"{}\"".format(url))
 else:
     webbrowser.open(url)
+
+asyncio.get_event_loop().run_until_complete(gdb_server.start(GDB_PORT))
 asyncio.get_event_loop().run_forever()


### PR DESCRIPTION
- Add support for GDB debugging with Wokwi simulator.
- Only share one file (which includes bootloader, partition table, and app binary) to Wokwi. 